### PR TITLE
✨ [Feat] 성경 버전 별 PPT 생성 및 UI 렌더링 기능 구현

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -49,10 +49,10 @@ ipcMain.handle('fetch-verse', (event, input: string, version: string = 'GAE') =>
   }
 });
 
-ipcMain.handle('generate-slide', async (event, data: { input: string; version?: string }) => {
+ipcMain.handle('generate-slide', async (event, data: { input: string; bibleVersion: string }) => {
   try {
-    const { input, version = 'GAE' } = data;
-    const verses = fetchVerses(input, version);
+    const { input, bibleVersion } = data;
+    const verses = fetchVerses(input, bibleVersion);
 
     let pptx: any; // pptx 객체는 generatePPT에서 관리
     verses.forEach((verse, idx) => {

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import path from 'path';
+import PptxGenJS from 'pptxgenjs';
 import { fileURLToPath } from 'url';
 import { generatePPT } from './main/utils/generatePPT.ts';
 import { fetchVerses } from './main/utils/parseVerse.ts';
@@ -22,7 +23,6 @@ function createWindow() {
 
   if (isDev) {
     mainWindow.loadURL('http://localhost:5173');
-    // mainWindow.webContents.openDevTools();
   } else {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
@@ -54,15 +54,22 @@ ipcMain.handle('generate-slide', async (event, data: { input: string; bibleVersi
     const { input, bibleVersion } = data;
     const verses = fetchVerses(input, bibleVersion);
 
-    let pptx: any; // pptx 객체는 generatePPT에서 관리
+    let pptx: PptxGenJS;
+
     verses.forEach((verse, idx) => {
-      console.log(verse);
       const title = `${verse.split(':')[1]} ${verse.split(':')[3]}장 ${verse.split(':')[4]}절`;
       const subTitle = `${verse.split(':')[1]} ${verse.split(':')[3]}장`;
-      const engTitle = `${verse.split(':')[2]} ${idx + 1}`;
-      const engSubTitle = `${verse.split(':')[2]} ${idx + 1}`;
+      const engTitle = `${verse.split(':')[2]} ${verse.split(':')[3]}:${verse.split(':')[4]}`;
+      const engSubTitle = `${verse.split(':')[2]} ${verse.split(':')[3]}`;
       const verseContent = `${verse.split(':')[5]}`;
-      pptx = generatePPT(title, subTitle, verseContent, pptx); // pptx가 undefined이면 새로 생성, 있으면 슬라이드 추가
+
+      if (bibleVersion === 'KJV' || bibleVersion === 'NIV') {
+        // 영어 버전인 경우, 제목과 소제목을 영어로 구성
+        pptx = generatePPT(engTitle, engSubTitle, verseContent, pptx);
+      } else {
+        // pptx가 undefined이면 새로 생성, 있으면 슬라이드 추가
+        pptx = generatePPT(title, subTitle, verseContent, pptx);
+      }
     });
 
     // 파일 저장 다이얼로그
@@ -75,7 +82,7 @@ ipcMain.handle('generate-slide', async (event, data: { input: string; bibleVersi
     });
 
     if (filePath) {
-      await pptx.writeFile({ fileName: filePath });
+      await pptx!.writeFile({ fileName: filePath });
       return { success: true, message: `File saved to ${filePath}` };
     }
 

--- a/app/main/constant/mockVerse.ts
+++ b/app/main/constant/mockVerse.ts
@@ -1,0 +1,10 @@
+export const mockVerse = {
+  개역개정:
+    '태초에 하나님이 천지를 창조하시니라 땅이 혼돈하고 공허하며 흑암이 깊음 위에 있고 하나님의 영은 수면 위에 운행하시니라 하나님이 이르시되 빛이 있으라 하시니 빛이 있었고',
+  개역한글:
+    '태초에 하나님이 천지를 창조하시니라 땅이 혼돈하고 공허하며 흑암이 깊음 위에 있고 하나님의 신은 수면에 운행하시니라 하나님이 가라사대 빛이 있으라 하시매 빛이 있었고',
+  새번역:
+    '태초에 하나님이 천지를 창조하셨다. 땅이 혼돈하고 공허하며, 어둠이 깊음 위에 있고, 하나님의 영은 물 위에 움직이고 계셨다. 하나님이 말씀하시기를 "빛이 생겨라" 하시니, 빛이 생겼다.',
+  KJV: 'In the beginning God created the heaven and the earth. And the earth was without form, and void; and darkness was upon the face of the deep. And the Spirit of God moved upon the face of the waters. And God said, Let there be light: and there was light.',
+  NIV: 'In the beginning God created the heavens and the earth. Now the earth was formless and empty, darkness was over the surface of the deep, and the Spirit of God was hovering over the waters. And God said, "Let there be light," and there was light.',
+};

--- a/app/main/utils/parseVerse.ts
+++ b/app/main/utils/parseVerse.ts
@@ -56,14 +56,24 @@ function parseInput(input: string): {
 }
 
 // 기존 fetchVerses 함수는 그대로 사용 가능합니다.
-export function fetchVerses(input: string, version: string = 'GAE'): string[] {
+export function fetchVerses(input: string, version: string): string[] {
+  // Version 객체
+  const abbrVersion: any = {
+    개역개정: 'GAE',
+    개역한글: 'RHV',
+    새번역: 'SAENEW',
+    KJV: 'KJV',
+    NIV: 'NIV',
+  } as const;
+
   // 새로 만든 parseInput 함수가 여기서 사용됩니다.
   const { book, fullName, engName, chapter, startVerse, endVerse } = parseInput(input);
   const verses: string[] = [];
+  const versionKey = abbrVersion[version];
 
   for (let v = startVerse; v <= endVerse; v++) {
     // bibleData의 key는 표준 약어('창')를 사용하므로 문제없이 동작합니다.
-    const verseText = (bibleData as any)?.[version]?.[book]?.[chapter]?.[v];
+    const verseText = (bibleData as any)?.[versionKey]?.[book]?.[chapter]?.[v];
     if (!verseText) {
       throw new Error(`${book} ${chapter}:${v} 구절을 찾을 수 없습니다.`);
     }

--- a/src/hooks/usePPTGenerator.ts
+++ b/src/hooks/usePPTGenerator.ts
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import useUserSettings from '../contexts/useUserSettings';
 
 const usePPTGenerator = () => {
@@ -15,6 +15,7 @@ const usePPTGenerator = () => {
 
     const data = {
       input: settings.verseInput,
+      bibleVersion: settings.bibleVersion,
       font: settings.font,
       textSize: settings.textSize,
       letterSpacing: settings.letterSpacing,

--- a/src/ui/Content.tsx
+++ b/src/ui/Content.tsx
@@ -1,12 +1,9 @@
 import styles from './Content.module.css';
 import useUserSettings from '../contexts/useUserSettings';
+import { mockVerse } from '../../app/main/constant/mockVerse';
 
 const Content = () => {
-  const { settings, setSettings } = useUserSettings();
-  const verseText = `태초에 하나님이 천지를 창조하시니라
-땅이 혼돈하고 공허하며 흑암이 깊음 위에 있고
-하나님의 영은 수면 위에 운행하시니라
-하나님이 이르시되 빛이 있으라 하시니 빛이 있었고`;
+  const { settings } = useUserSettings();
 
   return (
     <div className={styles.previewArea}>
@@ -21,7 +18,7 @@ const Content = () => {
             fontFamily: `${settings.font}`,
           }}
         >
-          <p className={styles.verseLine}>{verseText}</p>
+          <p className={styles.verseLine}>{mockVerse[settings.bibleVersion]}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## ✨ 주요 변경 사항

### 성경 버전 지원
- 성경 번역본(개역개정, KJV, NIV 등)에 따른 PPT 생성 기능 구현
- 성경 버전에 따라 제목/소제목을 조건부 렌더링하도록 수정
- Preview 패널에서 선택한 성경 버전의 구절을 실시간 반영

### 구현 상세
- 전역 상태에 성경 버전 선택 옵션 추가
- PPT 생성 시 선택한 성경 버전에 맞춰 슬라이드 데이터 구성
- Preview 패널 및 UI 컴포넌트가 버전 별로 조건부 렌더링되도록 개선