### PR TITLE
✅ [Test] 메인 프로세스 단위 테스트 추가 

### DIFF
--- a/src/main/index.test.ts
+++ b/src/main/index.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { app, BrowserWindow } from 'electron';
+import { checkForUpdates, setupAutoUpdater } from './services/updater';
+import { registerVerseHandler } from './ipc/verseHandler';
+import { registerPPTHandler } from './ipc/pptHandler';
+
+// 의존성 모듈 모의
+vi.mock('./services/updater', () => ({
+  setupAutoUpdater: vi.fn(),
+  checkForUpdates: vi.fn(),
+}));
+vi.mock('./ipc/verseHandler', () => ({
+  registerVerseHandler: vi.fn(),
+}));
+vi.mock('./ipc/pptHandler', () => ({
+  registerPPTHandler: vi.fn(),
+}));
+
+// Electron 모듈 모의
+const mockLoadURL = vi.fn();
+const mockLoadFile = vi.fn();
+const mockOpenDevTools = vi.fn();
+// 생성자 호출 감지용 Mock
+const mockBrowserWindowCtor = vi.fn();
+
+vi.mock('electron', () => {
+  return {
+    app: {
+      whenReady: vi.fn().mockResolvedValue(true),
+      on: vi.fn(),
+      quit: vi.fn(),
+      isPackaged: true, // 기본: 패키징됨
+    },
+    // BrowserWindow를 클래스로 정의
+    BrowserWindow: class {
+      constructor(options: any) {
+        mockBrowserWindowCtor(options);
+      }
+      loadURL = mockLoadURL;
+      loadFile = mockLoadFile;
+      webContents = { openDevTools: mockOpenDevTools };
+      // static methods
+      static getAllWindows = vi.fn().mockReturnValue([]);
+    }
+  };
+});
+
+describe('메인 프로세스 진입점 (index.ts)', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.ELECTRON_RENDERER_URL = '';
+    
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true
+    });
+    // 기본값 리셋
+    (app as any).isPackaged = true;
+  });
+
+  afterEach(() => {
+    delete process.env.ELECTRON_RENDERER_URL;
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true
+    });
+  });
+
+  it('앱 시작 시 초기화 함수들을 호출해야 한다', async () => {
+    await import('./index');
+    expect(setupAutoUpdater).toHaveBeenCalled();
+    expect(registerVerseHandler).toHaveBeenCalled();
+    expect(registerPPTHandler).toHaveBeenCalled();
+  });
+
+  it('기본 설정(프로덕션) 시 loadFile과 업데이트 확인을 호출해야 한다', async () => {
+    await import('./index');
+    await new Promise(process.nextTick);
+    
+    // 생성자 옵션 검증
+    expect(mockBrowserWindowCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+            width: 1020,
+            height: 720,
+            webPreferences: expect.objectContaining({ sandbox: false })
+        })
+    );
+
+    expect(mockLoadFile).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+    expect(mockLoadURL).not.toHaveBeenCalled();
+    expect(checkForUpdates).toHaveBeenCalled();
+  });
+
+  it('패키징되지 않은 환경(isPackaged=false)에서는 업데이트를 확인하지 않아야 한다', async () => {
+    (app as any).isPackaged = false;
+    
+    await import('./index');
+    await new Promise(process.nextTick);
+
+    expect(checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('개발 환경(ELECTRON_RENDERER_URL 설정) 시 loadURL과 openDevTools를 호출해야 한다', async () => {
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173';
+    
+    await import('./index');
+    await new Promise(process.nextTick);
+
+    expect(mockBrowserWindowCtor).toHaveBeenCalled();
+    expect(mockLoadURL).toHaveBeenCalledWith('http://localhost:5173');
+    expect(mockOpenDevTools).toHaveBeenCalledWith({ mode: 'detach' });
+    expect(mockLoadFile).not.toHaveBeenCalled();
+  });
+
+  it('window-all-closed 이벤트 발생 시 darwin(mac)이 아니면 앱을 종료해야 한다', async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true 
+    });
+
+    await import('./index');
+
+    const calls = (app.on as Mock).mock.calls;
+    const closedHandler = calls.find(call => call[0] === 'window-all-closed')?.[1];
+    
+    expect(closedHandler).toBeDefined();
+    closedHandler();
+
+    expect(app.quit).toHaveBeenCalled();
+  });
+
+  it('window-all-closed 이벤트 발생 시 darwin(mac)이면 앱을 종료하지 않아야 한다', async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin',
+      configurable: true
+    });
+
+    await import('./index');
+
+    const calls = (app.on as Mock).mock.calls;
+    const closedHandler = calls.find(call => call[0] === 'window-all-closed')?.[1];
+    
+    closedHandler();
+
+    expect(app.quit).not.toHaveBeenCalled();
+  });
+
+  it('activate 이벤트 발생 시 열린 창이 없으면 createWindow를 호출해야 한다', async () => {
+    await import('./index');
+
+    // 이벤트 등록 확인
+    const calls = (app.on as Mock).mock.calls;
+    const activateHandler = calls.find(call => call[0] === 'activate')?.[1];
+    expect(typeof activateHandler).toBe('function');
+
+    // 초기 실행으로 한 번 호출되었으므로 카운트 초기화
+    mockBrowserWindowCtor.mockClear();
+
+    // 열린 창이 없음 (모의)
+    (BrowserWindow as any).getAllWindows.mockReturnValue([]);
+
+    // 핸들러 실행
+    activateHandler();
+
+    expect(mockBrowserWindowCtor).toHaveBeenCalled();
+  });
+
+  it('activate 이벤트 발생 시 이미 창이 열려있으면 createWindow를 호출하지 않아야 한다', async () => {
+    await import('./index');
+
+    const calls = (app.on as Mock).mock.calls;
+    const activateHandler = calls.find(call => call[0] === 'activate')?.[1];
+
+    mockBrowserWindowCtor.mockClear();
+
+    // 창 1개 존재 (모의)
+    (BrowserWindow as any).getAllWindows.mockReturnValue([{}]); 
+
+    activateHandler();
+
+    expect(mockBrowserWindowCtor).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,18 +1,8 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron';
-import { AppUpdater, autoUpdater } from 'electron-updater';
+import { app, BrowserWindow } from 'electron';
 import path, { join } from 'path';
-import PptxGenJS from 'pptxgenjs';
-import { generatePPT } from './utils/generatePPT.ts';
-import { fetchVerses } from './utils/parseVerse.ts';
-
-interface WindowsUpdater extends AppUpdater {
-  verifyUpdateCodeSignature: boolean;
-}
-
-// 이 설정이 있어야 인증서(Code Signing) 없이도 GitHub Release 업데이트가 작동합니다.
-if (process.platform === 'win32') {
-  (autoUpdater as WindowsUpdater).verifyUpdateCodeSignature = false;
-}
+import { checkForUpdates, setupAutoUpdater } from './services/updater.ts';
+import { registerVerseHandler } from './ipc/verseHandler.ts';
+import { registerPPTHandler } from './ipc/pptHandler.ts';
 
 let mainWindow: BrowserWindow | null;
 
@@ -41,152 +31,24 @@ function createWindow() {
   }
 }
 
-// 1. 업데이트 다운로드 완료 시 실행 (가장 중요)
-autoUpdater.on('update-downloaded', (info) => {
-  const dialogOpts = {
-    type: 'info' as const,
-    buttons: ['재시작 및 설치', '나중에'],
-    title: '업데이트 알림',
-    message: `새로운 버전(${info.version})이 준비되었습니다.`,
-    detail: '앱을 재시작하여 업데이트를 적용하시겠습니까?',
-  };
+// AutoUpdater 설정 초기화
+setupAutoUpdater();
 
-  dialog.showMessageBox(dialogOpts).then((returnValue) => {
-    if (returnValue.response === 0) {
-      // '재시작 및 설치' 클릭 시
-      autoUpdater.quitAndInstall(false, true);
-    }
-  });
-});
-
-// 2. 에러 발생 시 로그 출력 (선택 사항: 사용자에게 알릴 수도 있음)
-autoUpdater.on('error', (message) => {
-  console.error('업데이트 오류 발생:', message);
-});
-
-// 3. 업데이트 확인 중 (선택 사항: 디버깅용)
-autoUpdater.on('checking-for-update', () => {
-  console.log('업데이트 확인 중...');
-});
-
-// 4. 업데이트가 가능할 때 (선택 사항)
-autoUpdater.on('update-available', () => {
-  console.log('새로운 업데이트가 있습니다.');
-});
+// IPC 핸들러 등록
+registerVerseHandler();
+registerPPTHandler();
 
 app.whenReady().then(() => {
   createWindow();
 
   if (app.isPackaged) {
-    autoUpdater.checkForUpdatesAndNotify();
+    checkForUpdates();
   }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
 });
-
-// -------------------------
-// IPC 핸들러: 성경 구절 가져오기
-// -------------------------
-ipcMain.handle('fetch-verse', (event, input: string, bibleVersion: string = 'GAE') => {
-  try {
-    const verses = fetchVerses(input, bibleVersion);
-    return verses;
-  } catch (err: unknown) {
-    return [`Error: ${(err as Error).message}`];
-  }
-});
-
-// -------------------------
-// IPC 핸들러: PPT 생성하기
-// -------------------------
-ipcMain.handle(
-  'generate-slide',
-  async (
-    event,
-    data: {
-      input: string;
-      bibleVersion: string;
-      align: 'left' | 'center' | 'right';
-      font: string;
-      isBold: '가늘게' | '굵게';
-      textSize: number;
-      letterSpacing: number;
-      lineHeight: number;
-    }
-  ) => {
-    try {
-      const { input, bibleVersion, align, font, isBold, textSize, letterSpacing, lineHeight } = data;
-      const verses = fetchVerses(input, bibleVersion);
-
-      let fontWeight;
-      if (isBold === '가늘게') {
-        fontWeight = false;
-      } else {
-        fontWeight = true;
-      }
-
-      let pptx: PptxGenJS;
-
-      verses.forEach((verse, idx) => {
-        const title = `${verse.split(':')[1]} ${verse.split(':')[3]}장 ${verse.split(':')[4]}절`;
-        const subTitle = `${verse.split(':')[1]} ${verse.split(':')[3]}장`;
-        const engTitle = `${verse.split(':')[2]} ${verse.split(':')[3]}:${verse.split(':')[4]}`;
-        const engSubTitle = `${verse.split(':')[2]} ${verse.split(':')[3]}`;
-        const verseContent = `${verse.split(':')[5]}`;
-
-        if (bibleVersion === 'KJV' || bibleVersion === 'NIV') {
-          // 영어 버전인 경우, 제목과 소제목을 영어로 구성
-          pptx = generatePPT(
-            engTitle,
-            engSubTitle,
-            verseContent,
-            align,
-            font,
-            fontWeight,
-            textSize,
-            letterSpacing,
-            lineHeight,
-            pptx
-          );
-        } else {
-          // pptx가 undefined이면 새로 생성, 있으면 슬라이드 추가
-          pptx = generatePPT(
-            title,
-            subTitle,
-            verseContent,
-            align,
-            font,
-            fontWeight,
-            textSize,
-            letterSpacing,
-            lineHeight,
-            pptx
-          );
-        }
-      });
-
-      // 파일 저장 다이얼로그
-      const saveFileName = input.replace(/^([가-힣a-zA-Z]+)\s*(\d+)[:|-](.*)$/, '$1$2장$3절');
-
-      const { filePath } = await dialog.showSaveDialog({
-        title: 'Save PowerPoint File',
-        defaultPath: `${saveFileName}.pptx`,
-        filters: [{ name: 'PowerPoint', extensions: ['pptx'] }],
-      });
-
-      if (filePath) {
-        await pptx!.writeFile({ fileName: filePath });
-        return { success: true, message: `파일이 ${filePath}에 저장되었습니다.` };
-      }
-
-      return { success: false, message: '파일 저장이 취소되었습니다.' };
-    } catch (err: unknown) {
-      return `PPT 슬라이드 생성 오류:  ${(err as Error).message}`;
-    }
-  }
-);
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();

--- a/src/main/ipc/pptHandler.test.ts
+++ b/src/main/ipc/pptHandler.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { ipcMain, dialog } from 'electron';
+import { registerPPTHandler } from './pptHandler';
+import { fetchVerses } from '../utils/parseVerse';
+import { generatePPT } from '../utils/generatePPT';
+
+// Electron 모듈 모의 (Mock)
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  dialog: {
+    showSaveDialog: vi.fn(),
+  },
+}));
+
+// pptxgenjs 모듈 모의
+vi.mock('pptxgenjs', () => ({
+  default: class {
+    writeFile = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+// 유틸리티 함수 모의
+vi.mock('../utils/generatePPT', () => ({
+  generatePPT: vi.fn(),
+}));
+
+vi.mock('../utils/parseVerse', () => ({
+  fetchVerses: vi.fn(),
+}));
+
+describe('PPT 생성 핸들러 (PPT Handler)', () => {
+  let handler: Function;
+
+  // 테스트용 기본 데이터
+  const mockData = {
+    input: 'John 3:16',
+    bibleVersion: 'GAE',
+    align: 'center' as const,
+    font: 'Arial',
+    isBold: '굵게' as const,
+    textSize: 20,
+    letterSpacing: 0,
+    lineHeight: 1.5,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // ipcMain.handle 등록 가로채기
+    (ipcMain.handle as Mock).mockImplementation((channel, listener) => {
+      if (channel === 'generate-slide') {
+        handler = listener;
+      }
+    });
+    
+    // 핸들러 등록 함수 실행
+    registerPPTHandler();
+  });
+
+  it('generate-slide 핸들러가 ipcMain에 등록되어야 한다', () => {
+    expect(ipcMain.handle).toHaveBeenCalledWith('generate-slide', expect.any(Function));
+  });
+
+  it('PPT를 생성하고 사용자 지정 경로에 저장해야 한다', async () => {
+    // Mock: 성경 구절 파싱 결과 (형식: 분류:한글책명:영문책명:장:절:내용)
+    (fetchVerses as Mock).mockReturnValue(['Bible:요한복음:John:3:16:하나님이 세상을 이처럼 사랑하사...']);
+    // Mock: generatePPT는 pptx 객체를 반환 (여기서는 writeFile 메서드를 가진 객체)
+    (generatePPT as Mock).mockReturnValue({ writeFile: vi.fn().mockResolvedValue(undefined) });
+    // Mock: 저장 대화상자 결과
+    (dialog.showSaveDialog as Mock).mockResolvedValue({ filePath: 'C:/Users/Test/Desktop/BibleSlide_Test.pptx' });
+
+    const result = await handler({}, mockData);
+
+    // 검증
+    expect(fetchVerses).toHaveBeenCalledWith(mockData.input, mockData.bibleVersion);
+    expect(generatePPT).toHaveBeenCalled();
+    expect(dialog.showSaveDialog).toHaveBeenCalled();
+    expect(result).toEqual({ success: true, message: '파일이 C:/Users/Test/Desktop/BibleSlide_Test.pptx에 저장되었습니다.' });
+  });
+
+  it('KJV/NIV 등 영어 성경 요청 시 영문 제목으로 PPT를 생성해야 한다', async () => {
+    // Mock: 영어 성경 구절
+    (fetchVerses as Mock).mockReturnValue(['Bible:요한복음:John:3:16:For God so loved the world...']);
+    (generatePPT as Mock).mockReturnValue({ writeFile: vi.fn().mockResolvedValue(undefined) });
+    (dialog.showSaveDialog as Mock).mockResolvedValue({ filePath: 'C:/save.pptx' });
+
+    // 실행 (버전을 KJV로 변경)
+    await handler({}, { ...mockData, bibleVersion: 'KJV' });
+
+    // 검증: generatePPT가 호출될 때 영문 제목(John 3:16)이 첫 번째 인자로 전달되었는지 확인
+    // generatePPT 시그니처: (title, subTitle, content, ...)
+    expect(generatePPT).toHaveBeenCalledWith(
+        expect.stringContaining('John 3:16'), // title (영문)
+        expect.stringContaining('John 3'),    // subTitle (영문)
+        expect.stringContaining('For God'),   // content
+        mockData.align,
+        mockData.font,
+        true, // isBold='굵게' -> true
+        mockData.textSize,
+        mockData.letterSpacing,
+        mockData.lineHeight,
+        undefined // 첫 호출 시 pptx 객체는 undefined
+    );
+  });
+
+  it('파일 저장 대화상자에서 취소 시 실패 메시지를 반환해야 한다', async () => {
+    (fetchVerses as Mock).mockReturnValue(['Bible:요한복음:John:3:16:내용']);
+    (generatePPT as Mock).mockReturnValue({ writeFile: vi.fn() });
+    // Mock: 취소 (filePath가 비어있거나 undefined)
+    (dialog.showSaveDialog as Mock).mockResolvedValue({ cancelled: true, filePath: '' });
+
+    const result = await handler({}, mockData);
+
+    expect(result).toEqual({ success: false, message: '파일 저장이 취소되었습니다.' });
+  });
+
+  it('PPT 생성 또는 저장 중 오류 발생 시 에러 메시지를 반환해야 한다', async () => {
+    (fetchVerses as Mock).mockReturnValue(['Bible:요한복음:John:3:16:내용']);
+    // Mock: generatePPT 내부에서 에러 발생
+    (generatePPT as Mock).mockImplementation(() => {
+        throw new Error('폰트 로드 실패');
+    });
+
+    const result = await handler({}, mockData);
+
+    expect(result).toContain('PPT 슬라이드 생성 오류');
+    expect(result).toContain('폰트 로드 실패');
+  });
+
+  it('isBold가 "가늘게"인 경우 fontWeight를 false로 설정해야 한다', async () => {
+    (fetchVerses as Mock).mockReturnValue(['Bible:요한복음:John:3:16:내용']);
+    (generatePPT as Mock).mockReturnValue({ writeFile: vi.fn().mockResolvedValue(undefined) });
+    (dialog.showSaveDialog as Mock).mockResolvedValue({ filePath: 'C:/save.pptx' });
+
+    // 실행 (isBold를 '가늘게'로 변경)
+    await handler({}, { ...mockData, isBold: '가늘게' });
+
+    // 검증: 6번째 인자가 fontWeight (false여야 함)
+    expect(generatePPT).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        false, // fontWeight expected to be false
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        undefined // 1st call pptx is undefined
+    );
+  });
+});

--- a/src/main/ipc/pptHandler.ts
+++ b/src/main/ipc/pptHandler.ts
@@ -1,0 +1,97 @@
+import { ipcMain, dialog } from 'electron';
+import PptxGenJS from 'pptxgenjs';
+import { generatePPT } from '../utils/generatePPT';
+import { fetchVerses } from '../utils/parseVerse';
+
+export function registerPPTHandler(): void {
+  // -------------------------
+  // IPC 핸들러: PPT 생성하기
+  // -------------------------
+  ipcMain.handle(
+    'generate-slide',
+    async (
+      event,
+      data: {
+        input: string;
+        bibleVersion: string;
+        align: 'left' | 'center' | 'right';
+        font: string;
+        isBold: '가늘게' | '굵게';
+        textSize: number;
+        letterSpacing: number;
+        lineHeight: number;
+      }
+    ) => {
+      try {
+        const { input, bibleVersion, align, font, isBold, textSize, letterSpacing, lineHeight } =
+          data;
+        const verses = fetchVerses(input, bibleVersion);
+
+        let fontWeight;
+        if (isBold === '가늘게') {
+          fontWeight = false;
+        } else {
+          fontWeight = true;
+        }
+
+        let pptx: PptxGenJS | undefined;
+
+        verses.forEach((verse, idx) => {
+          const title = `${verse.split(':')[1]} ${verse.split(':')[3]}장 ${verse.split(':')[4]}절`;
+          const subTitle = `${verse.split(':')[1]} ${verse.split(':')[3]}장`;
+          const engTitle = `${verse.split(':')[2]} ${verse.split(':')[3]}:${verse.split(':')[4]}`;
+          const engSubTitle = `${verse.split(':')[2]} ${verse.split(':')[3]}`;
+          const verseContent = `${verse.split(':')[5]}`;
+
+          if (bibleVersion === 'KJV' || bibleVersion === 'NIV') {
+            // 영어 버전인 경우, 제목과 소제목을 영어로 구성
+            pptx = generatePPT(
+              engTitle,
+              engSubTitle,
+              verseContent,
+              align,
+              font,
+              fontWeight,
+              textSize,
+              letterSpacing,
+              lineHeight,
+              pptx
+            );
+          } else {
+            // pptx가 undefined이면 새로 생성, 있으면 슬라이드 추가
+            pptx = generatePPT(
+              title,
+              subTitle,
+              verseContent,
+              align,
+              font,
+              fontWeight,
+              textSize,
+              letterSpacing,
+              lineHeight,
+              pptx
+            );
+          }
+        });
+
+        // 파일 저장 다이얼로그
+        const saveFileName = input.replace(/^([가-힣a-zA-Z]+)\s*(\d+)[:|-](.*)$/, '$1$2장$3절');
+
+        const { filePath } = await dialog.showSaveDialog({
+          title: 'Save PowerPoint File',
+          defaultPath: `${saveFileName}.pptx`,
+          filters: [{ name: 'PowerPoint', extensions: ['pptx'] }],
+        });
+
+        if (filePath) {
+          await pptx!.writeFile({ fileName: filePath });
+          return { success: true, message: `파일이 ${filePath}에 저장되었습니다.` };
+        }
+
+        return { success: false, message: '파일 저장이 취소되었습니다.' };
+      } catch (err: unknown) {
+        return `PPT 슬라이드 생성 오류:  ${(err as Error).message}`;
+      }
+    }
+  );
+}

--- a/src/main/ipc/verseHandler.test.ts
+++ b/src/main/ipc/verseHandler.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { ipcMain } from 'electron';
+import { registerVerseHandler } from './verseHandler';
+import { fetchVerses } from '../utils/parseVerse';
+
+// Electron ipcMain 모의
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
+// 구절 파싱 유틸리티 모의
+vi.mock('../utils/parseVerse', () => ({
+  fetchVerses: vi.fn(),
+}));
+
+describe('성경 구절 핸들러 (Verse Handler)', () => {
+  let handler: Function;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // 핸들러 캡처
+    (ipcMain.handle as Mock).mockImplementation((channel, listener) => {
+      if (channel === 'fetch-verse') {
+        handler = listener;
+      }
+    });
+    
+    registerVerseHandler();
+  });
+
+  it('fetch-verse 채널에 핸들러가 등록되어야 한다', () => {
+    expect(ipcMain.handle).toHaveBeenCalledWith('fetch-verse', expect.any(Function));
+  });
+
+  it('정상적인 입력에 대해 파싱된 구절 배열을 반환해야 한다', async () => {
+    const mockOutput = ['창세기 1장 1절 태초에...', '창세기 1장 2절 땅이...'];
+    (fetchVerses as Mock).mockReturnValue(mockOutput);
+
+    // 핸들러 실행 (event 객체는 빈 객체로 전달)
+    const result = await handler({}, '창 1:1-2', 'GAE');
+
+    expect(fetchVerses).toHaveBeenCalledWith('창 1:1-2', 'GAE');
+    expect(result).toEqual(mockOutput);
+  });
+
+  it('버전 인자가 없을 경우 기본값(GAE)으로 호출해야 한다', async () => {
+    (fetchVerses as Mock).mockReturnValue([]);
+    
+    await handler({}, '창 1:1'); // version 인자 생략
+
+    expect(fetchVerses).toHaveBeenCalledWith('창 1:1', 'GAE');
+  });
+
+  it('파싱 중 에러 발생 시 에러 메시지가 담긴 배열을 반환해야 한다', async () => {
+    (fetchVerses as Mock).mockImplementation(() => {
+      throw new Error('유효하지 않은 구절입니다');
+    });
+
+    const result = await handler({}, '잘못된입력');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('Error');
+    expect(result[0]).toContain('유효하지 않은 구절입니다');
+  });
+});

--- a/src/main/ipc/verseHandler.ts
+++ b/src/main/ipc/verseHandler.ts
@@ -1,0 +1,16 @@
+import { ipcMain } from 'electron';
+import { fetchVerses } from '../utils/parseVerse';
+
+export function registerVerseHandler(): void {
+  // -------------------------
+  // IPC 핸들러: 성경 구절 가져오기
+  // -------------------------
+  ipcMain.handle('fetch-verse', (event, input: string, bibleVersion: string = 'GAE') => {
+    try {
+      const verses = fetchVerses(input, bibleVersion);
+      return verses;
+    } catch (err: unknown) {
+      return [`Error: ${(err as Error).message}`];
+    }
+  });
+}

--- a/src/main/services/updater.test.ts
+++ b/src/main/services/updater.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { autoUpdater } from 'electron-updater';
+import { dialog } from 'electron';
+import { setupAutoUpdater, checkForUpdates } from './updater';
+
+// Electron 모듈 모의
+vi.mock('electron', () => ({
+  dialog: {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+  },
+}));
+
+// Electron-Updater 모듈 모의
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    on: vi.fn(),
+    checkForUpdatesAndNotify: vi.fn(),
+    quitAndInstall: vi.fn(),
+    verifyUpdateCodeSignature: true,
+  },
+  AppUpdater: class {},
+}));
+
+describe('자동 업데이트 서비스 (Updater Service)', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true
+    });
+    // 기본적으로 서명 검증 true로 초기화 (테스트 격리를 위해)
+    (autoUpdater as any).verifyUpdateCodeSignature = true;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true
+    });
+  });
+
+  it('초기화 시 이벤트 리스너들이 등록되어야 한다', () => {
+    setupAutoUpdater();
+    
+    // 주요 이벤트 리스너 등록 확인
+    expect(autoUpdater.on).toHaveBeenCalledWith('update-downloaded', expect.any(Function));
+    expect(autoUpdater.on).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(autoUpdater.on).toHaveBeenCalledWith('checking-for-update', expect.any(Function));
+    expect(autoUpdater.on).toHaveBeenCalledWith('update-available', expect.any(Function));
+  });
+
+  it('Windows 플랫폼에서는 verifyUpdateCodeSignature를 false로 설정해야 한다', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true
+    });
+
+    setupAutoUpdater();
+    expect((autoUpdater as any).verifyUpdateCodeSignature).toBe(false);
+  });
+
+  it('macOS 등 다른 플랫폼에서는 verifyUpdateCodeSignature를 변경하지라 않아야 한다 (기본값 유지)', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin',
+      configurable: true
+    });
+    // 재설정을 위해 true로 명시적 초기화
+    (autoUpdater as any).verifyUpdateCodeSignature = true;
+
+    setupAutoUpdater();
+    expect((autoUpdater as any).verifyUpdateCodeSignature).toBe(true);
+  });
+
+  it('업데이트 확인 함수 호출 시 autoUpdater를 트리거해야 한다', () => {
+    checkForUpdates();
+    expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalled();
+  });
+
+  it('업데이트 다운로드 완료 후 사용자가 "재시작 및 설치"를 선택하면 quitAndInstall을 호출해야 한다', async () => {
+    let downloadCallback: Function | undefined;
+    (autoUpdater.on as Mock).mockImplementation((event, cb) => {
+      if (event === 'update-downloaded') {
+        downloadCallback = cb;
+      }
+    });
+    
+    // 사용자가 '재시작' (버튼 인덱스 0) 선택 모의
+    (dialog.showMessageBox as Mock).mockResolvedValue({ response: 0 });
+
+    setupAutoUpdater();
+    const mockInfo = { version: '2.0.0' };
+    
+    // 이벤트 트리거
+    await downloadCallback!(mockInfo);
+
+    expect(dialog.showMessageBox).toHaveBeenCalled();
+    // nextTick 대기 (showMessageBox promise resolution)
+    await new Promise(process.nextTick);
+
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+  });
+
+  it('업데이트 다운로드 완료 후 사용자가 "나중에"를 선택하면 quitAndInstall을 호출하지 않아야 한다', async () => {
+    let downloadCallback: Function | undefined;
+    (autoUpdater.on as Mock).mockImplementation((event, cb) => {
+      if (event === 'update-downloaded') {
+        downloadCallback = cb;
+      }
+    });
+
+    // 사용자가 '나중에' (버튼 인덱스 1) 선택 모의
+    (dialog.showMessageBox as Mock).mockResolvedValue({ response: 1 });
+
+    setupAutoUpdater();
+    const mockInfo = { version: '2.0.0' };
+    
+    await downloadCallback!(mockInfo);
+
+    expect(dialog.showMessageBox).toHaveBeenCalled();
+    await new Promise(process.nextTick);
+
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  describe('콘솔 로그 이벤트 테스트', () => {
+    let consoleLogSpy: any;
+    let consoleErrorSpy: any;
+
+    beforeEach(() => {
+      consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleLogSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    // 헬퍼 함수: 특정 이벤트의 콜백을 가져오는 함수
+    const getEventCallback = (eventName: string): Function | undefined => {
+      const calls = (autoUpdater.on as Mock).mock.calls;
+      const call = calls.find(c => c[0] === eventName);
+      return call ? call[1] : undefined;
+    };
+
+    it('에러 발생 시(error) 콘솔에 에러를 출력해야 한다', () => {
+      setupAutoUpdater();
+      const callback = getEventCallback('error');
+      expect(callback).toBeDefined();
+
+      const errorMsg = '네트워크 연결 실패';
+      callback!(errorMsg);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('업데이트 오류 발생:', errorMsg);
+    });
+
+    it('업데이트 확인 중(checking-for-update)일 때 로그를 출력해야 한다', () => {
+      setupAutoUpdater();
+      const callback = getEventCallback('checking-for-update');
+      expect(callback).toBeDefined();
+
+      callback!();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('업데이트 확인 중...');
+    });
+
+    it('업데이트가 가능할 때(update-available) 로그를 출력해야 한다', () => {
+      setupAutoUpdater();
+      const callback = getEventCallback('update-available');
+      expect(callback).toBeDefined();
+
+      callback!();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('새로운 업데이트가 있습니다.');
+    });
+  });
+});

--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -1,0 +1,50 @@
+import { dialog } from 'electron';
+import { AppUpdater, autoUpdater } from 'electron-updater';
+
+interface WindowsUpdater extends AppUpdater {
+  verifyUpdateCodeSignature: boolean;
+}
+
+export function setupAutoUpdater(): void {
+  // 이 설정이 있어야 인증서(Code Signing) 없이도 GitHub Release 업데이트가 작동합니다.
+  if (process.platform === 'win32') {
+    (autoUpdater as WindowsUpdater).verifyUpdateCodeSignature = false;
+  }
+
+  // 1. 업데이트 다운로드 완료 시 실행 (가장 중요)
+  autoUpdater.on('update-downloaded', (info) => {
+    const dialogOpts = {
+      type: 'info' as const,
+      buttons: ['재시작 및 설치', '나중에'],
+      title: '업데이트 알림',
+      message: `새로운 버전(${info.version})이 준비되었습니다.`,
+      detail: '앱을 재시작하여 업데이트를 적용하시겠습니까?',
+    };
+
+    dialog.showMessageBox(dialogOpts).then((returnValue) => {
+      if (returnValue.response === 0) {
+        // '재시작 및 설치' 클릭 시
+        autoUpdater.quitAndInstall(false, true);
+      }
+    });
+  });
+
+  // 2. 에러 발생 시 로그 출력 (선택 사항: 사용자에게 알릴 수도 있음)
+  autoUpdater.on('error', (message) => {
+    console.error('업데이트 오류 발생:', message);
+  });
+
+  // 3. 업데이트 확인 중 (선택 사항: 디버깅용)
+  autoUpdater.on('checking-for-update', () => {
+    console.log('업데이트 확인 중...');
+  });
+
+  // 4. 업데이트가 가능할 때 (선택 사항)
+  autoUpdater.on('update-available', () => {
+    console.log('새로운 업데이트가 있습니다.');
+  });
+}
+
+export function checkForUpdates(): void {
+  autoUpdater.checkForUpdatesAndNotify();
+}

--- a/src/renderer/contexts/UserSettingsContext.test.tsx
+++ b/src/renderer/contexts/UserSettingsContext.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, renderHook } from '@testing-library/react';
+import { UserSettingsProvider } from './UserSettingsContext';
+import useUserSettings from './useUserSettings';
+
+// useDeviceOS 모킹
+vi.mock('../hooks/useDeviceOS', () => ({
+  default: vi.fn(),
+}));
+
+import useDeviceOS from '../hooks/useDeviceOS';
+
+describe('UserSettingsContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('UserSettingsProvider', () => {
+    it('children을 정상적으로 렌더링해야 한다', () => {
+      (useDeviceOS as any).mockReturnValue('Unknown');
+
+      render(
+        <UserSettingsProvider>
+          <div data-testid="child">Child Content</div>
+        </UserSettingsProvider>
+      );
+
+      expect(screen.getByTestId('child')).toBeInTheDocument();
+      expect(screen.getByText('Child Content')).toBeInTheDocument();
+    });
+
+    it('Windows OS인 경우 폰트 이름 뒤에 Medium을 붙여야 한다', () => {
+      (useDeviceOS as any).mockReturnValue('Windows');
+
+      const TestComponent = () => {
+        const { settings } = useUserSettings();
+        return <div data-testid="font">{settings.font}</div>;
+      };
+
+      render(
+        <UserSettingsProvider>
+          <TestComponent />
+        </UserSettingsProvider>
+      );
+
+      expect(screen.getByTestId('font')).toHaveTextContent('KoPubWorld바탕체 Medium');
+    });
+
+    it('Windows가 아닌 경우 기본 폰트 이름을 사용해야 한다', () => {
+      (useDeviceOS as any).mockReturnValue('MacOS');
+
+      const TestComponent = () => {
+        const { settings } = useUserSettings();
+        return <div data-testid="font">{settings.font}</div>;
+      };
+
+      render(
+        <UserSettingsProvider>
+          <TestComponent />
+        </UserSettingsProvider>
+      );
+
+      expect(screen.getByTestId('font')).toHaveTextContent('KoPubWorld바탕체');
+    });
+
+    it('OS가 변경되면(예: 초기 로드 후 감지) 폰트 설정을 OS에 맞게 업데이트해야 한다', () => {
+      // 1. 처음에는 Unknown (Windows 아님)으로 시작
+      (useDeviceOS as any).mockReturnValue('Unknown');
+
+      const TestComponent = () => {
+        const { settings } = useUserSettings();
+        return <div data-testid="font">{settings.font}</div>;
+      };
+
+      const { rerender } = render(
+        <UserSettingsProvider>
+          <TestComponent />
+        </UserSettingsProvider>
+      );
+
+      expect(screen.getByTestId('font')).toHaveTextContent('KoPubWorld바탕체');
+
+      // 2. OS가 Windows로 변경됨을 시뮬레이션
+      (useDeviceOS as any).mockReturnValue('Windows');
+
+      // 3. 재렌더링하여 변경된 mock 값을 반영
+      rerender(
+        <UserSettingsProvider>
+          <TestComponent />
+        </UserSettingsProvider>
+      );
+
+      // 4. useEffect가 동작하여 폰트가 업데이트되었는지 확인
+      expect(screen.getByTestId('font')).toHaveTextContent('KoPubWorld바탕체 Medium');
+    });
+  });
+
+  describe('useUserSettings Hook', () => {
+    it('Provider 내부에서 사용 시 설정을 조회하고 업데이트할 수 있어야 한다', async () => {
+      (useDeviceOS as any).mockReturnValue('MacOS');
+
+      const { result } = renderHook(() => useUserSettings(), {
+        wrapper: UserSettingsProvider,
+      });
+
+      // 초기값 확인
+      expect(result.current.settings.bibleVersion).toBe('개역개정');
+
+      // 업데이트 실행
+      await act(async () => {
+        result.current.setSettings((prev) => ({
+          ...prev,
+          bibleVersion: '새번역',
+        }));
+      });
+
+      // 업데이트 반영 확인
+      expect(result.current.settings.bibleVersion).toBe('새번역');
+    });
+
+    it('Provider 외부에서 사용 시 에러를 던져야 한다', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useUserSettings());
+      }).toThrow('useUserSettings는 UserSettingsProvider 내부에서 사용해야 합니다.');
+
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/renderer/hooks/useDeviceOS.test.ts
+++ b/src/renderer/hooks/useDeviceOS.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import useDeviceOS from './useDeviceOS';
+
+describe('useDeviceOS', () => {
+  const originalUserAgent = window.navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+
+  function mockUserAgent(userAgent: string) {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: userAgent,
+      configurable: true,
+    });
+  }
+
+  it('Windows UserAgent를 감지해야 한다', () => {
+    mockUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    const { result } = renderHook(() => useDeviceOS());
+    expect(result.current).toBe('Windows');
+  });
+
+  it('MacOS UserAgent를 감지해야 한다', () => {
+    mockUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    const { result } = renderHook(() => useDeviceOS());
+    expect(result.current).toBe('MacOS');
+  });
+
+  it('iOS (iPhone) UserAgent를 감지해야 한다', () => {
+    mockUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)');
+    const { result } = renderHook(() => useDeviceOS());
+    expect(result.current).toBe('iOS');
+  });
+
+  it('Android UserAgent를 감지해야 한다', () => {
+    mockUserAgent('Mozilla/5.0 (Linux; Android 11; SM-G991B)');
+    const { result } = renderHook(() => useDeviceOS());
+    expect(result.current).toBe('Android');
+  });
+
+  it('Linux UserAgent를 감지해야 한다', () => {
+    mockUserAgent('Mozilla/5.0 (X11; Linux x86_64)');
+    const { result } = renderHook(() => useDeviceOS());
+    expect(result.current).toBe('Linux');
+  });
+
+  it('알 수 없는 UserAgent는 Unknown을 반환해야 한다', () => {
+    mockUserAgent('UnknownBot/1.0');
+    const { result } = renderHook(() => useDeviceOS());
+    expect(result.current).toBe('Unknown');
+  });
+});

--- a/src/renderer/tests/setup.ts
+++ b/src/renderer/tests/setup.ts
@@ -7,4 +7,6 @@ class ResizeObserverMock {
   disconnect() {}
 }
 
-window.ResizeObserver = ResizeObserverMock;
+if (typeof window !== 'undefined') {
+  window.ResizeObserver = ResizeObserverMock;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "outDir": "./build",
     "noEmit": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "app", "types"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/renderer/tests/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      exclude: [
+        '**/*.json',
+        '**/*.css',
+        '**/*.d.ts',
+        '**/*.config.*',
+        '**/tests/setup.ts',
+      ],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 🚀 작업 요약 (Summary)
Main 프로세스 단위 테스트 시행

## 🛠️ 주요 변경 사항 (Key Changes)
- 비대해진 index.ts 로직 분리 및 모듈화
- AutoUpdater 관련 로직을 services/updater.ts로 이동
- IPC 통신 로직(성경 구절 검색, PPT 생성)을 ipc/ 디렉토리 하위로 분리
- vitest.config.ts에 설정 파일 및 CSS 등 커버리지 측정 예외(exclude) 규칙 추가
## ✅ 테스트 결과 (Test Results)
모든 단위 테스트가 로컬 환경에서 통과함 (npm run test)
핵심 로직(hooks)의 커버리지 100% 달성 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized core services into modular components for improved maintainability and code organization.
  * Centralized auto-update handling for more reliable update behavior.

* **Tests**
  * Added comprehensive test coverage for core application services, handlers, and utilities to ensure reliability and stability.

* **Chores**
  * Updated configuration files to support enhanced testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->